### PR TITLE
Added cleanEmptyChannels()

### DIFF
--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -120,6 +120,7 @@ class Server{
         t_str_c   getPartMessage()                                    const;
         t_str_c   itostr                  (int i)                     const;
         void broadcast       (t_str_c& sender, t_str_c& channelName, t_str_c& message);
+        void      cleanEmptyChannels();
 
         /* <------ server replies -----> */
         void RPL_CAP       (int socket);

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -199,6 +199,10 @@ void Server::Messages(int socket){
     // else if (m_command == "PASS")
     //     comparePassword();
     // }
+    
+    /* @note error prone, if you access empty channels afterwards */
+    cleanEmptyChannels();
+
 }
 
 // void Server::comparePassword(){
@@ -208,6 +212,25 @@ void Server::Messages(int socket){
 // 		throw sendError()
 // 		writeToOutputBuffer(ERR_PASSWD)
 // }
+
+void Server::cleanEmptyChannels(){
+    
+
+    t_vec_str_c channelNames = split(um.getChannelNames(), ',');
+    log_vector("channelNames", channelNames);
+
+    for (t_vec_str_cit it = channelNames.begin();
+                       it != channelNames.end();
+                       ++it){
+        
+        t_str_c channelName = *it;
+        Channel const* channel = um.getChannel(channelName);
+        if (channel->getNumberOfUsers() == 0){
+            um.eraseChannel(channelName);
+            log(channelName + " has been removed (no Users)");
+        }
+    }
+}
 
 bool Server::checkUnallowedCharacters(t_str_c& stringToCheck,
                                       t_str_c& unallowedChars) const{


### PR DESCRIPTION
Added function to clean all empty Channels from server. Has been added to Server::Message() routine, might be error prone if you access the same Channel afterwards. But in theory it should work, because Response messages have been prepared by that time.